### PR TITLE
Minor version 181 added

### DIFF
--- a/vars/java_8.yml
+++ b/vars/java_8.yml
@@ -1,6 +1,9 @@
 ---
 
 java_builds:
+  - minor: 181
+    build: 13
+    download_id: '96a7b8442fe848ef90c96a2fad6ed6d1'
   - minor: 172
     build: 11
     download_id: 'a58eab1ec242421181065cdc37240b08'


### PR DESCRIPTION
Looks like other minor versions are obsolete now and throw a 404 error on download.